### PR TITLE
fixed broken slack API link

### DIFF
--- a/assets/script/background.js
+++ b/assets/script/background.js
@@ -1,8 +1,7 @@
 const nasaUrl='https://api.nasa.gov/planetary/apod?api_key=xO8d0RCLIdY6C1PoXiXLhIuaUiKvgaZ0N6BrsflD';
 
 var bgImage = document.getElementById('bgimage');
-console.log (bgImage);
-console.log (bgImage.src);
+// default image
 bgImage.src="https://www.fillmurray.com/1920/1080";
 
 function getApi(requestUrl) {

--- a/assets/script/script.js
+++ b/assets/script/script.js
@@ -13,21 +13,23 @@ jokeBtn.addEventListener("click", function () {
     })
     .then((data) => {
     //   console.log("RESPONSE", data.joke);
-      jokeText.innerHTML = data.joke;
-      
-    });
+    //
+    jokeText.innerHTML = data.joke;  // <---- instead of putting this in jokeText -what if you just stuck it right on the banner hero page?
     
+    //
+    // code to post jokes to slack
+    // Weird - the OLD API link was https://hooks.slack.com/services/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
+    // 3-4-21 jason.e.jones@gmail.com went back to slack, there were no webhook APIs, so I created a NEW one
+    // and tested the joke posting and it worked?  Not sure why or how the webhook was deleted at slack that's really weird
+    //
+    
+    var url = "https://hooks.slack.com/services/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";
+    var payload = { text: data.joke };
+    $.post(url, JSON.stringify(payload), function (data) {
+      console.log("I just slacked this joke " + JSON.stringify(payload));
+    });
+    })
+    .catch((err) => {
+      console.error(err);       
+    });
 })
-
-
-//
-//     var url =
-//       "https://hooks.slack.com/services/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";
-//     var payload = { text: data.joke };
-//     $.post(url, JSON.stringify(payload), function (data) {
-//       console.log("I just slacked this joke " + JSON.stringify(payload));
-//     });
-//   })
-//   .catch((err) => {
-//     console.error(err);
-//   

--- a/assets/script/script.js
+++ b/assets/script/script.js
@@ -22,8 +22,9 @@ jokeBtn.addEventListener("click", function () {
     // 3-4-21 jason.e.jones@gmail.com went back to slack, there were no webhook APIs, so I created a NEW one
     // and tested the joke posting and it worked?  Not sure why or how the webhook was deleted at slack that's really weird
     //
-    
-    var url = "https://hooks.slack.com/services/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";
+
+    // var url = "https://hooks.slack.com/services/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";
+    var url = "https://hooks.slack.com/services/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";
     var payload = { text: data.joke };
     $.post(url, JSON.stringify(payload), function (data) {
       console.log("I just slacked this joke " + JSON.stringify(payload));


### PR DESCRIPTION
Really weird - this was working - you didn't do anything wrong - it stopped working (error code 404) because the webhook api that WAS FOR SURE working last night was deleted on slack.  No clue how that happened.  very strange.  
Ideally we should endeavor to be more bulletproof in error catching.  If the attempt to post to slack does not succeed - then we maybe log that to console and be done.  ICEBOX that bullet proofing!! :-)