### PR TITLE
details to the interactive element

### DIFF
--- a/assets/script/apodexplorer.js
+++ b/assets/script/apodexplorer.js
@@ -6,20 +6,34 @@ function getApi2(requestUrl) {
         return response.json();
       })
       .then(function (data) {
-        bgImage.src=data.url;
-        bgImage.alt=data.title;  
-        console.log ("trying to set image again "+data);
-        return (data);
+        console.log(data);
+        if (data.media_type == "image") {    
+          bgImage.src=data.url;
+          console.log("bgImage is "+bgImage.src);
+          bgImage.alt=data.title;  
+        } else {
+          bgImage.src="https://cdn.pixabay.com/photo/2019/02/17/22/01/color-4003283_960_720.jpg";
+          bgImage.atl="On the selected date, the APOD is a video.  But we don't use videos for backgrounds."
+        }
       });
   }
 
 
 $( function() {
-    $( "#datepicker" ).datepicker({dateFormat: 'yy-mm-dd'});
+  //
+  // maxDate: "+0D" so you can't pick a date in the future
+  // minDate: "June 16 1995" is the first image in the APOD
+  //
+
+    $( "#datepicker" ).datepicker({
+      dateFormat: 'yy-mm-dd', 
+      maxDate: "+0D",
+      changeYear: true,
+      minDate: new Date('1995/6/16')
+    });
     } );
 
 $("#datepicker").on("change", function(){
-    console.log($(this).val());  
     queryUrl=nasaUrl+"&date="+$(this).val();
     getApi2(queryUrl);
     });

--- a/index.html
+++ b/index.html
@@ -26,10 +26,13 @@
       <p><strong> About NASA image: </strong></p>
       <!-- NASA IMAGE INFO HERE! -->
     </div>
+    <div class="container has-text-centered">
+      Interact with this Date Picker to change the background image
+    </div>
   </section>
   <section>
-    <div class="container text-is-centered is-centered" id="interactive-element">
-      <div class="columns text-is-centered is-centered" id="datepicker">
+    <!-- <div class="columns is-centered" id="interactive-element"> -->
+      <div class="columns is-centered" id="datepicker">
       </div>
     </div>
   </section>
@@ -43,18 +46,11 @@
 
   </body>
   <script src="https://kit.fontawesome.com/737d647828.js" crossorigin="anonymous"></script>
-  <!-- <script
-    src="https://code.jquery.com/jquery-3.6.0.min.js"
-    integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4="
-    crossorigin="anonymous"></script> -->
-    <script src="https://code.jquery.com/jquery-1.12.4.js"></script>
-    <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
-  
+  <script src="https://code.jquery.com/jquery-1.12.4.js"></script>
+  <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
   <script src="assets/script/script.js"></script>
   <script src="assets/script/background.js"></script>
   <script src="assets/script/description.js"></script>
-  
-  <!-- <script src="assets/bulma-calendar/js/bulma-calendar.js"></script> -->
   <script src="assets/script/apodexplorer.js"></script>
 
 </html>


### PR DESCRIPTION
the calendar date picker has been changed as follows:
1. the selectable dates are locked down to the range between when the first APOD was posted and today - because you do not want to pick a date of a picture before they were a thing, and you certainly can not pick a date in the future
2. the datepicker has been changed to allow for changing of year
3. sometimes, but not often, the Astronomy Picture of the Day is in fact a VIDEO.  So - when that happens we will just so a pretty image from a website i thought looked nice.